### PR TITLE
replace the deprecated driver class

### DIFF
--- a/backend/trafficrules/src/main/resources/application.yaml
+++ b/backend/trafficrules/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:trafficrules}
     username: ${DATABASE_USER:root}
     password: ${DATABASE_PASSWORD}


### PR DESCRIPTION
This is done to fix the following log warning:
```
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
```